### PR TITLE
Adjusting coords array length in lowpower sources

### DIFF
--- a/source/tracker-lowpower-otaa.ino
+++ b/source/tracker-lowpower-otaa.ino
@@ -42,7 +42,7 @@ static const u1_t PROGMEM APPKEY[16] = { 0x6C, 0x10, 0x63, 0x2D, 0xD5, 0xD2, 0xF
 void os_getDevKey (u1_t* buf) {  memcpy_P(buf, APPKEY, 16);}
 
 
-uint8_t coords[8];
+uint8_t coords[9];
 uint32_t LatitudeBinary, LongitudeBinary;
 uint16_t altitudeGps;
 uint8_t hdopGps;

--- a/source/tracker-lowpower.ino
+++ b/source/tracker-lowpower.ino
@@ -30,7 +30,7 @@ void os_getArtEui (u1_t* buf) { }
 void os_getDevEui (u1_t* buf) { }
 void os_getDevKey (u1_t* buf) { }
 
-uint8_t coords[8];
+uint8_t coords[9];
 uint32_t LatitudeBinary, LongitudeBinary;
 uint16_t altitudeGps;
 uint8_t hdopGps;


### PR DESCRIPTION
Hello Bjoern,

thank you for your code. I used it to map my lora gateway. While using the lowpower sources I found that `coords[]` had the wrong length. I used this to try my first pull request, maybe you accept my pull request?

Changes `uint8_t coords[8]` to `uint8_t coords[9]` in line 33.

Greetings
Richard